### PR TITLE
feat: add base REPL implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,9 @@ name = "monkey_interpreter"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+path = "src/main.rs"
+name = "monkey_interpreter"
 
 [dependencies]
 once_cell = "1.13.0"

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -1,7 +1,7 @@
 use crate::token::{Token, TokenType};
 
 /// Lexer of the Monkey language
-struct Lexer {
+pub struct Lexer {
     input: Vec<char>,
     current_pos: usize,
     next_read_pos: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
 
-mod lexer;
-mod token;
+pub mod lexer;
+pub mod repl;
+pub mod token;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,14 @@
 #![allow(dead_code)]
 
+use std::io::{stdin, stdout};
+
+use monkey_interpreter::repl;
+
 fn main() {
-    println!("Hello, world!");
+    println!("Starting REPL...");
+
+    let stdin = stdin();
+    let stdout = stdout();
+
+    repl::start_repl(stdin, stdout);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@ fn main() {
     println!("Starting REPL...");
 
     let stdin = stdin();
-    let stdout = stdout();
+    let mut stdout = stdout();
 
-    repl::start_repl(stdin, stdout);
+    // Might not be the best to have a lock for so long
+    repl::start_repl(&mut stdin.lock(), &mut stdout);
 }

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,0 +1,30 @@
+use std::io::{Stdin, Stdout, Write};
+
+use crate::{lexer, token::TokenType};
+
+const PROMPT: &str = ">> ";
+
+pub fn start_repl(input: Stdin, mut output: Stdout) {
+    loop {
+        // TODO: handle errors more gracefully
+        output.write_all(PROMPT.as_bytes()).unwrap();
+        output.flush().unwrap();
+
+        let mut str_buffer = String::new();
+        // TODO: handle errors more gracefully
+        input.read_line(&mut str_buffer).unwrap();
+
+        let mut lexer = lexer::Lexer::new(str_buffer);
+
+        while let Some(token) = lexer.next_token() {
+            if token.token_type == TokenType::Eof {
+                return;
+            }
+
+            // TODO: handle errors more gracefully
+            output
+                .write_all(format!("{:?}\n", token.token_type).as_bytes())
+                .unwrap();
+        }
+    }
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -17,7 +17,9 @@ pub fn start_repl(input: &mut dyn BufRead, output: &mut dyn Write) {
         let mut lexer = lexer::Lexer::new(str_buffer);
 
         while let Some(token) = lexer.next_token() {
-            if token.token_type == TokenType::Eof {
+            if token.token_type == TokenType::Eof
+                || token.token_type == TokenType::Ident("exit".into())
+            {
                 return;
             }
 

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -30,3 +30,24 @@ pub fn start_repl(input: &mut dyn BufRead, output: &mut dyn Write) {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::io::{BufReader, BufWriter};
+
+    use super::start_repl;
+
+    #[test]
+    fn test() {
+        let input = String::from("let five = 5;exit");
+
+        let mut buffer_read = BufReader::new(input.as_bytes());
+        let mut buffer_write = BufWriter::new(vec![0; 50]);
+
+        start_repl(&mut buffer_read, &mut buffer_write);
+
+        let printed = String::from_utf8(buffer_write.buffer().to_owned()).unwrap();
+
+        assert_eq!(printed, "Let\nIdent(\"five\")\nAssign\nInt(5)\nSemicolon\n");
+    }
+}

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -1,10 +1,10 @@
-use std::io::{Stdin, Stdout, Write};
+use std::io::{BufRead, Write};
 
 use crate::{lexer, token::TokenType};
 
 const PROMPT: &str = ">> ";
 
-pub fn start_repl(input: Stdin, mut output: Stdout) {
+pub fn start_repl(input: &mut dyn BufRead, output: &mut dyn Write) {
     loop {
         // TODO: handle errors more gracefully
         output.write_all(PROMPT.as_bytes()).unwrap();


### PR DESCRIPTION
### Added
- Binary definition in `Cargo.toml`
- REPL module

### Changed 
- Fix exports in some places (`pub` missing)
- Base `main.rs` to launch REPL